### PR TITLE
fix: diffs are wrapped in :body when passed for formatting

### DIFF
--- a/lib/pact/xml/diff_formatter.rb
+++ b/lib/pact/xml/diff_formatter.rb
@@ -20,9 +20,11 @@ module Pact
       end
 
       def self.call(
-          diff,
+          result,
           options = { colour: Pact.configuration.color_enabled }
         )
+        diff = result[:body]
+        return '' if diff.nil?
         diff.map { |d| make_line d, options }.join NEWLINE
       end
     end

--- a/spec/lib/pact/xml/diff_formatter_spec.rb
+++ b/spec/lib/pact/xml/diff_formatter_spec.rb
@@ -8,10 +8,13 @@ module Pact
   module XML
     describe DiffFormatter do
       let(:diff) do
-        [
-          Difference.new('a', 'b', 'Expected a but got b'),
-          Difference.new('x', 'y', 'Expected x but got y')
-        ]
+        {
+          body:
+          [
+            Difference.new('a', 'b', 'Expected a but got b'),
+            Difference.new('x', 'y', 'Expected x but got y')
+          ]
+        }
       end
 
       subject { DiffFormatter.call(diff, options) }
@@ -28,7 +31,7 @@ module Pact
 
       describe '.call' do
         context 'when no diffs' do
-          let(:diff) { [] }
+          let(:diff) { {} }
 
           it { expect(subject).to be_empty }
         end


### PR DESCRIPTION
The issue seems to be with diffs passed in a wrapped object `{:body => diffs}`,  e.g., 
```ruby
{:body=>[#<Pact::Matchers::Difference:0x007fb72e59cfa8 @expected="bar", @actual="WIFFLE", @message="Expected attribute bar but got WIFFLE at $.foo.thing.@name">]}
```
It's probably best to remove this knowledge from differ if possible and rely on array being passed in instead of a specific hash. Anyways, this seems to work when integrated with pact-ruby (pact-ruby-e2e-example).

Excerpt from logs:
```sh
# cat bar_mock_service.log
E, [2018-07-23T20:39:49.521404 #72173] ERROR -- : No matching interaction found for POST /thing
E, [2018-07-23T20:39:49.521453 #72173] ERROR -- : Interaction diffs for that route:
E, [2018-07-23T20:39:49.523228 #72173] ERROR -- : Diff with interaction: "a retrieve thing request"
EXPECTED : bar
ACTUAL   : WIFFLE
MESSAGE  : Expected attribute bar but got WIFFLE at $.foo.thing.@name
```

```ruby
# cat bar_spec.rb
+ expect(bar_response.body).to eql ({})
expect(bar_response.status).to eql 201
```

Mock server response on error now resembles that of JSON:

```javascript
{
  "message": "No interaction found for POST /thing",
  "interaction_diffs": [
    {
      "description": "a retrieve thing request",
      "body": [
        {
          "EXPECTED": "bar",
          "ACTUAL": "WIFFLE"
        }
      ]
    }
  ]
}
```